### PR TITLE
app: Fix xmlelement warning

### DIFF
--- a/pyqgiswps/app/request.py
+++ b/pyqgiswps/app/request.py
@@ -175,7 +175,7 @@ class WPSResponse:
         # rebuild the doc and update the status xml file
         self.document = self.get_execute_response()
         # check if storing of the status is requested
-        if self.document:
+        if len(self.document) > 0:
             self._write_response_doc(self.uuid, self.document)
         if self.status >= WPSResponse.STATUS.DONE_STATUS:
             self.process.clean()


### PR DESCRIPTION
This fixes the following warning:

```
/usr/local/lib/python3.9/dist-packages/pyqgiswps/app/request.py:178: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if self.document:
```

