### PR TITLE
filesio: parse_output_definition cleanup

### DIFF
--- a/pyqgiswps/executors/io/filesio.py
+++ b/pyqgiswps/executors/io/filesio.py
@@ -135,8 +135,8 @@ def parse_output_definition(outdef: QgsProcessingOutputDefinition, kwargs,
             if isinstance(inputdef, QgsProcessingParameterFileDestination):
                 default_mime = mimetypes.types_map.get("." + inputdef.defaultFileExtension())
                 default_mime_idx = -1
+                extension_regex = re.compile(r'.*([.][a-z]+)')
                 for filter_ in inputdef.fileFilter().split(";;"):
-                    extension_regex = re.compile(r'.*([.][a-z]+)')
                     match = extension_regex.match(filter_)
                     if match:
                         mime = mimetypes.types_map.get(match.group(1))


### PR DESCRIPTION
The `extension_regex` variable can be created once.

This fixes commit c2fa739acf4bda8da291d02194dfa1f2a7f59ba7
