### PR TITLE
Fix makefile following pyproject migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
-# 
+#
 # qypws makefile
 #
 DEPTH=.
@@ -32,7 +32,7 @@ deliver:
 	twine upload $(TWINE_OPTIONS) -r $(PYPISERVER) $(DIST)/*
 
 dist: dirs manifest
-	rm -rf *.egg-info 
+	rm -rf *.egg-info
 	$(PYTHON) -m build --no-isolation --sdist --outdir=$(DIST)
 
 clean:
@@ -70,4 +70,3 @@ client-test:
 
 scan:
 	@bandit -c pyproject.toml -r pyqgiswps
-

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ version:
 	echo $(VERSION_TAG) > VERSION
 
 manifest: version
-	echo name=$(shell $(PYTHON) setup.py --name) > $(MANIFEST) && \
-	echo version=$(shell $(PYTHON) setup.py --version) >> $(MANIFEST) && \
+	echo name=$(PROJECT_NAME) > $(MANIFEST) && \
+	echo version=$(VERSION_TAG) >> $(MANIFEST) && \
 	echo buildid=$(BUILDID)   >> $(MANIFEST) && \
 	echo commitid=$(COMMITID) >> $(MANIFEST)
 

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ version:
 
 manifest: version
 	echo name=$(shell $(PYTHON) setup.py --name) > $(MANIFEST) && \
-    echo version=$(shell $(PYTHON) setup.py --version) >> $(MANIFEST) && \
-    echo buildid=$(BUILDID)   >> $(MANIFEST) && \
-    echo commitid=$(COMMITID) >> $(MANIFEST)
+	echo version=$(shell $(PYTHON) setup.py --version) >> $(MANIFEST) && \
+	echo buildid=$(BUILDID)   >> $(MANIFEST) && \
+	echo commitid=$(COMMITID) >> $(MANIFEST)
 
 deliver:
 	twine upload $(TWINE_OPTIONS) -r $(PYPISERVER) $(DIST)/*

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,5 @@
+# Name to be set in the manifest
+PROJECT_NAME:=py-qgis-wps
 
 VERSION:=1.9.0
 


### PR DESCRIPTION
The `makefile` was still using the removed `setup.py`
