### PR TITLE
pyproject: Specify setuptools minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 ]
 dependencies = [
     "tornado >= 6",
-    "pyzmq >= 17", 
+    "pyzmq >= 17",
     "PyYAML",
     "OWSLib",
     "psutil",


### PR DESCRIPTION
Prior to this version, this command from the `Makefile` fails:

```
python3 -m build --no-isolation --sdist
```
