### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/pyqgiswps/executors/processfactory.py
+++ b/pyqgiswps/executors/processfactory.py
@@ -115,7 +115,7 @@ class _FactoryDelegate(Process):
                 p.start()
                 p.join()
                 # Test non-zero exitcode
-                # This happends on Qgs provider registration failure because PyQgis exception are not
+                # This happens on Qgs provider registration failure because PyQgis exception are not
                 # propagated to python
                 if p.exitcode != 0:
                     LOGGER.critical("Sub process exited with code %s", p.exitcode)
@@ -249,7 +249,7 @@ class QgsProcessFactory:
         self.qgis_enabled = True
         # Re-create the sub-processes
         if _is_android:
-            LOGGER.warn("Android platform detected: restarting processes may not behave as expected")
+            LOGGER.warning("Android platform detected: restarting processes may not behave as expected")
             processes = self._create_qgis_processes()
         else:
             if not self._delegate:
@@ -274,7 +274,7 @@ class QgsProcessFactory:
     def start_qgis(self):
         """ Set up qgis
         """
-        # Do not intialize twice
+        # Do not initialize twice
         if self.qgisapp is not None:
             return
 

--- a/pyqgiswps/inout/basic.py
+++ b/pyqgiswps/inout/basic.py
@@ -52,7 +52,7 @@ class BasicHandler:
         self.valid_mode = mode
 
     def check_valid(self):
-        """Validate this input usig given validator
+        """Validate this input using given validator
         """
         validate = self.validator
         valid = validate(self, self.valid_mode)
@@ -119,7 +119,7 @@ class IOHandler(BasicHandler):
                     case str():
                         return StringIO(self.source)
                     case _:
-                        LOGGER.warn("Converting %s to stream", type(self.source))
+                        LOGGER.warning("Converting %s to stream", type(self.source))
                         return StringIO(str(self.source))
 
     def set_data(self, data):


### PR DESCRIPTION
**Description:**
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```